### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive Model Context Protocol (MCP) server that provides seamless integration with the Fastly NGWAF (Next-Gen Web Application Firewall) API. This server enables AI assistants like Claude to manage web application security through natural language interactions.
 
+<a href="https://glama.ai/mcp/servers/@purpleax/FastlyMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@purpleax/FastlyMCP/badge" alt="Fastly NGWAF Server MCP server" />
+</a>
+
 ## Features
 
 🛡️ **Complete WAF Management**


### PR DESCRIPTION
This PR adds a badge for the [Fastly NGWAF MCP Server](https://glama.ai/mcp/servers/@purpleax/FastlyMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@purpleax/FastlyMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@purpleax/FastlyMCP/badge" alt="Fastly NGWAF Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.